### PR TITLE
Use 'latest' tag in docker-compose.yml and don't download entire repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ A Raspberry Pi running with [Docker and Docker Compose installed](https://docs.d
 
 ## On rpi:
 
-- `sudo git clone https://github.com/ryansch/docker-unifi-rpi /opt/unifi && cd /opt/unifi`
-- `sudo docker-compose up -d`
+1. `mkdir unifi && cd unifi`
+2. `curl -O https://raw.githubusercontent.com/ryansch/docker-unifi-rpi/master/docker-compose.yml`
+3. (Optional) Edit `docker-compose.yml` to point to a different tag if you don't want `latest`.
+4. `sudo docker-compose up -d`
 
 ## From any computer on your network:
 
-- Visit https://raspberrypi.local:8443/ with your browser. Replace `raspberrypi.local` with the actual hostname or local network IP address of your Raspberry Pi.
+Visit https://raspberrypi.local:8443/ with your browser. Replace `raspberrypi.local` with the actual hostname or local network IP address of your Raspberry Pi.
 
-## Building
+# Building
 - `docker build --pull -t ryansch/unifi-rpi:<version> <version>`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   unifi:
-    image: ryansch/unifi-rpi:v5
+    image: ryansch/unifi-rpi:latest
     container_name: unifi
     restart: always
     network_mode: host


### PR DESCRIPTION
- Usage `latest` instead of `v5` tag in `docker-compose.yml` -- I'm assuming this is functionally the same, but more future proof.
- Change instructions to use a home level directory to avoid sudo usage and since the previous instructions didn't actually work since you can't `cd` into `/opt/unifi` to run the docker-compose file
- Instructions now only download `docker-compose.yml` instead of cloning the entire repo since that seemed unnecessary