### PR TITLE
Adding 6.0.43 and replace GPG keyserver with keyserver.ubuntu.com

### DIFF
--- a/6.0/Dockerfile.amd64
+++ b/6.0/Dockerfile.amd64
@@ -13,7 +13,7 @@ RUN mkdir -p /tmp/build && \
 	cd /tmp/build && \
 	wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH} && \
 	wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH}.asc && \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver  keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify tini.asc tini && \
 	cp tini /sbin/ && \
 	chmod +x /sbin/tini && \
@@ -37,8 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install any version from deb download
 # Use dpkg to mark the package for install (expect it to fail to complete the installation)
 # Use apt-get install -f to complete the installation with dependencies
-ENV UNIFI_VERSION 6.0.41-5353824aa0
-ENV UNIFI_DOCKER_VERSION 6.0.41
+ENV UNIFI_VERSION 6.0.43
+ENV UNIFI_DOCKER_VERSION 6.0.43
 RUN mkdir -p /usr/share/man/man1 && \
       mkdir -p /tmp/build && \
       cd /tmp/build && \

--- a/6.0/Dockerfile.arm32v7
+++ b/6.0/Dockerfile.arm32v7
@@ -14,7 +14,7 @@ RUN mkdir -p /tmp/build && \
 	cd /tmp/build && \
 	wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH} && \
 	wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH}.asc && \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify tini.asc tini && \
 	cp tini /sbin/ && \
 	chmod +x /sbin/tini && \
@@ -42,8 +42,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install any version from deb download
 # Use dpkg to mark the package for install (expect it to fail to complete the installation)
 # Use apt-get install -f to complete the installation with dependencies
-ENV UNIFI_VERSION 6.0.41-5353824aa0
-ENV UNIFI_DOCKER_VERSION 6.0.41
+ENV UNIFI_VERSION 6.0.43
+ENV UNIFI_DOCKER_VERSION 6.0.43
 RUN mkdir -p /usr/share/man/man1 && \
       mkdir -p /tmp/build && \
       cd /tmp/build && \

--- a/6.0/Dockerfile.arm64v8
+++ b/6.0/Dockerfile.arm64v8
@@ -14,7 +14,7 @@ RUN mkdir -p /tmp/build && \
 	cd /tmp/build && \
 	wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH} && \
 	wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH}.asc && \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify tini.asc tini && \
 	cp tini /sbin/ && \
 	chmod +x /sbin/tini && \
@@ -40,8 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install any version from deb download
 # Use dpkg to mark the package for install (expect it to fail to complete the installation)
 # Use apt-get install -f to complete the installation with dependencies
-ENV UNIFI_VERSION 6.0.41-5353824aa0
-ENV UNIFI_DOCKER_VERSION 6.0.41
+ENV UNIFI_VERSION 6.0.43
+ENV UNIFI_DOCKER_VERSION 6.0.43
 RUN mkdir -p /usr/share/man/man1 && \
       mkdir -p /tmp/build && \
       cd /tmp/build && \

--- a/6.0/manifest.yml
+++ b/6.0/manifest.yml
@@ -1,19 +1,19 @@
-image: ryansch/unifi-rpi:6.0.41
+image: ryansch/unifi-rpi:6.0.43
 tags:
 manifests:
   -
-    image: ryansch/unifi-rpi:6.0.41-amd64
+    image: ryansch/unifi-rpi:6.0.43-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: ryansch/unifi-rpi:6.0.41-arm32v7
+    image: ryansch/unifi-rpi:6.0.43-arm32v7
     platform:
       architecture: arm
       os: linux
       variant: v7
   -
-    image: ryansch/unifi-rpi:6.0.41-arm64v8
+    image: ryansch/unifi-rpi:6.0.43-arm64v8
     platform:
       architecture: arm64
       os: linux

--- a/templates/Dockerfile.amd64
+++ b/templates/Dockerfile.amd64
@@ -13,7 +13,7 @@ RUN mkdir -p /tmp/build && \
 	cd /tmp/build && \
 	wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH} && \
 	wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH}.asc && \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver  keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify tini.asc tini && \
 	cp tini /sbin/ && \
 	chmod +x /sbin/tini && \

--- a/templates/Dockerfile.arm32v7
+++ b/templates/Dockerfile.arm32v7
@@ -14,7 +14,7 @@ RUN mkdir -p /tmp/build && \
 	cd /tmp/build && \
 	wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH} && \
 	wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH}.asc && \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify tini.asc tini && \
 	cp tini /sbin/ && \
 	chmod +x /sbin/tini && \

--- a/templates/Dockerfile.arm64v8
+++ b/templates/Dockerfile.arm64v8
@@ -14,7 +14,7 @@ RUN mkdir -p /tmp/build && \
 	cd /tmp/build && \
 	wget -O tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH} && \
 	wget -O tini.asc https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static${TINI_ARCH}.asc && \
-  gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
+  gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
   gpg --batch --verify tini.asc tini && \
 	cp tini /sbin/ && \
 	chmod +x /sbin/tini && \


### PR DESCRIPTION
There's a new version for Unifi.

The original GPG keyserver hkp://p80.pool.sks-keyservers.net:80 was failing contantly with the error: "gpg: keyserver receive failed: No data".

